### PR TITLE
chore: show the original and shortened link in the DOM

### DIFF
--- a/src/components/LinkInput/LinkInput.tsx
+++ b/src/components/LinkInput/LinkInput.tsx
@@ -1,4 +1,4 @@
-import { FormEvent,ChangeEvent, useState } from 'react';
+import { FormEvent,ChangeEvent, useState, useEffect } from 'react';
 import { getShortedLink } from '../../helpers/getShortedLink';
 import { ShortedLinkResult } from '../../types/types';
 
@@ -9,6 +9,13 @@ type FormProps = {
 export const LinkInput = ({setShortenedLink}:FormProps) => {
   const [inputValue, setInputValue] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
+
+  useEffect(() => {
+    const storedLinks:ShortedLinkResult = JSON.parse(localStorage.getItem('links')!);
+    if(storedLinks) {
+      setShortenedLink(storedLinks);
+    }
+  }, [setShortenedLink]);
 
   const handleInputValue = ({ target }:ChangeEvent<HTMLInputElement>) => {
     const newURL = target.value;
@@ -35,6 +42,7 @@ export const LinkInput = ({setShortenedLink}:FormProps) => {
     
     if(linkIsValid){
       const shortenedLink = await getShortedLink(inputValue);
+      localStorage.setItem('links', JSON.stringify(shortenedLink));
       setShortenedLink(shortenedLink);
       setInputValue('');
       setErrorMsg('');
@@ -53,5 +61,4 @@ export const LinkInput = ({setShortenedLink}:FormProps) => {
       </form>
     </div>
   )
-
 }

--- a/src/components/LinkInput/LinkInput.tsx
+++ b/src/components/LinkInput/LinkInput.tsx
@@ -1,7 +1,12 @@
 import { FormEvent,ChangeEvent, useState } from 'react';
 import { getShortedLink } from '../../helpers/getShortedLink';
+import { ShortedLinkResult } from '../../types/types';
 
-export const LinkInput = () => {
+type FormProps = {
+  setShortenedLink: (arg:ShortedLinkResult) => void;
+};
+
+export const LinkInput = ({setShortenedLink}:FormProps) => {
   const [inputValue, setInputValue] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
 
@@ -29,7 +34,8 @@ export const LinkInput = () => {
     const linkIsValid = validateLink(inputValue);
     
     if(linkIsValid){
-      await getShortedLink(inputValue);
+      const shortenedLink = await getShortedLink(inputValue);
+      setShortenedLink(shortenedLink);
       setInputValue('');
       setErrorMsg('');
     }

--- a/src/components/ShortenLink/ShortedLink.tsx
+++ b/src/components/ShortenLink/ShortedLink.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import { LinkInput } from '../LinkInput/LinkInput';
+import { ShortenedLinkItem } from '../ShortenedLinkItem/ShortenedLinkItem';
+import { ShortedLinkResult } from '../../types/types';
+
+export const ShortedLink = () => {
+
+  const [shortenedLink, setShortenedLink] = useState<ShortedLinkResult | null>(null);
+
+  return (
+    <>
+      <LinkInput setShortenedLink= {setShortenedLink}/>
+      <ShortenedLinkItem shortenedLink={shortenedLink}/>
+    </>
+  )
+}

--- a/src/components/ShortenLink/ShortedLink.tsx
+++ b/src/components/ShortenLink/ShortedLink.tsx
@@ -5,7 +5,7 @@ import { ShortedLinkResult } from '../../types/types';
 
 export const ShortedLink = () => {
 
-  const [shortenedLink, setShortenedLink] = useState<ShortedLinkResult | null>(null);
+  const [shortenedLink, setShortenedLink] = useState<ShortedLinkResult>();
 
   return (
     <>

--- a/src/components/ShortenLink/ShortedLink.tsx
+++ b/src/components/ShortenLink/ShortedLink.tsx
@@ -10,7 +10,7 @@ export const ShortedLink = () => {
   return (
     <>
       <LinkInput setShortenedLink= {setShortenedLink}/>
-      <ShortenedLinkItem shortenedLink={shortenedLink}/>
+      {shortenedLink && <ShortenedLinkItem shortenedLink={shortenedLink}/>}
     </>
   )
 }

--- a/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
+++ b/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
@@ -1,10 +1,8 @@
+import { useState } from 'react';
 import { ShortedLinkResult } from '../../types/types';
 import { copyToClipboard } from '../../helpers/copyToClipboard';
-import { useState } from 'react';
 
-type ResultProps = {
-  shortenedLink: ShortedLinkResult | null;
-}
+type ResultProps = { shortenedLink: ShortedLinkResult }
 
 export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
 
@@ -14,11 +12,18 @@ export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
   const shortLink = shortenedLink?.full_short_link;  
 
   const handleCopyText = () => {
-    copyToClipboard(shortLink!);
-    setCopyText('Copied!');
-    setTimeout(() => {
-      setCopyText('Copy');
-    }, 2000);
+    try {
+      copyToClipboard(shortLink!);
+      setCopyText('Copied!');
+      setTimeout(() => {
+        setCopyText('Copy');
+      }, 2000);
+    } catch (error) {
+      setCopyText('Copy error');
+      setTimeout(() => {
+        setCopyText('Copy');
+      }, 2000);
+    }
   }
 
   return (

--- a/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
+++ b/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
@@ -1,4 +1,6 @@
 import { ShortedLinkResult } from '../../types/types';
+import { copyToClipboard } from '../../helpers/copyToClipboard';
+import { useState } from 'react';
 
 type ResultProps = {
   shortenedLink: ShortedLinkResult | null;
@@ -6,14 +8,24 @@ type ResultProps = {
 
 export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
 
+  const [copyText, setCopyText] = useState('Copy');
+
   const originalLink = shortenedLink?.original_link;
-  const shortLink = shortenedLink?.full_short_link;
+  const shortLink = shortenedLink?.full_short_link;  
+
+  const handleCopyText = () => {
+    copyToClipboard(shortLink!);
+    setCopyText('Copied!');
+    setTimeout(() => {
+      setCopyText('Copy');
+    }, 2000);
+  }
 
   return (
     <div className="shortened-link-container">
       <p>{originalLink}</p>
       <p>{shortLink}</p>
-      <button>Copy</button>
+      <button onClick={handleCopyText}>{copyText}</button>
     </div>
   )
 }

--- a/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
+++ b/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
@@ -1,0 +1,19 @@
+import { ShortedLinkResult } from '../../types/types';
+
+type ResultProps = {
+  shortenedLink: ShortedLinkResult | null;
+}
+
+export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
+
+  const originalLink = shortenedLink?.original_link;
+  const shortLink = shortenedLink?.full_short_link;
+
+  return (
+    <div className="shortened-link-container">
+      <p>{originalLink}</p>
+      <p>{shortLink}</p>
+      <button>Copy</button>
+    </div>
+  )
+}

--- a/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
+++ b/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
@@ -8,12 +8,12 @@ export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
 
   const [copyText, setCopyText] = useState('Copy');
 
-  const originalLink = shortenedLink?.original_link;
-  const shortLink = shortenedLink?.full_short_link;  
+  const originalLink = shortenedLink.original_link;
+  const shortLink = shortenedLink.full_short_link;  
 
-  const handleCopyText = () => {
+  const handleCopyText = async ():Promise<void> => {
     try {
-      copyToClipboard(shortLink!);
+      await copyToClipboard(shortLink!);
       setCopyText('Copied!');
       setTimeout(() => {
         setCopyText('Copy');

--- a/src/components/UrlShorteningPage/UrlShorteningPage.tsx
+++ b/src/components/UrlShorteningPage/UrlShorteningPage.tsx
@@ -1,7 +1,8 @@
-import { LinkInput } from "../LinkInput/LinkInput"
-
+import { ShortedLink } from '../ShortenLink/ShortedLink';
 export const UrlShorteningPage = () => {
   return (
-    <LinkInput/>
+    <>
+      <ShortedLink/>
+    </>
   )
 }

--- a/src/helpers/copyToClipboard.ts
+++ b/src/helpers/copyToClipboard.ts
@@ -1,5 +1,3 @@
-export const copyToClipboard = (text:string) => {
-  navigator.clipboard.writeText(text)
-    .then(() => console.log('Copiado al portapapeles'))
-    .catch((error) => console.error('Error al copiar al portapapeles: ', error));
+export const copyToClipboard = (text:string):Promise<void> => {
+  return navigator.clipboard.writeText(text)
 }

--- a/src/helpers/copyToClipboard.ts
+++ b/src/helpers/copyToClipboard.ts
@@ -1,0 +1,5 @@
+export const copyToClipboard = (text:string) => {
+  navigator.clipboard.writeText(text)
+    .then(() => console.log('Copiado al portapapeles'))
+    .catch((error) => console.error('Error al copiar al portapapeles: ', error));
+}


### PR DESCRIPTION
La tareas asignadas en ese branch son las siguientes:

**_1.-_** Mostrar tanto el enlace original como el enlace acortado una vez que el usuario haya dado clic en el botón para acortar el enlace. 🔗

**_2.-_** El usuario podrá copiar el enlace acortado a su portapapeles con un solo clic. 🖱

**_3.-_** Ver sus enlaces abreviados, incluso después de actualizar el navegador. 🔄

![image](https://github.com/AlanPinhon/url-shortening-page-ts/assets/74801980/f8b72589-f33b-4512-ae70-dd687468208b)
