### PR TITLE
feat: replaced link shortening API

### DIFF
--- a/src/components/LinkInput/LinkInput.tsx
+++ b/src/components/LinkInput/LinkInput.tsx
@@ -1,9 +1,9 @@
 import { FormEvent,ChangeEvent, useState, useEffect } from 'react';
 import { getShortedLink } from '../../helpers/getShortedLink';
-import { ShortedLinkResult } from '../../types/types';
+import { LinkResponseData } from '../../types/types';
 
 type FormProps = {
-  setShortenedLink: (arg:ShortedLinkResult) => void;
+  setShortenedLink: (value:LinkResponseData) => void;
 };
 
 export const LinkInput = ({setShortenedLink}:FormProps) => {
@@ -11,7 +11,7 @@ export const LinkInput = ({setShortenedLink}:FormProps) => {
   const [errorMsg, setErrorMsg] = useState('');
 
   useEffect(() => {
-    const storedLinks:ShortedLinkResult = JSON.parse(localStorage.getItem('links')!);
+    const storedLinks:LinkResponseData = JSON.parse(localStorage.getItem('links')!);
     if(storedLinks) {
       setShortenedLink(storedLinks);
     }
@@ -41,7 +41,8 @@ export const LinkInput = ({setShortenedLink}:FormProps) => {
     const linkIsValid = validateLink(inputValue);
     
     if(linkIsValid){
-      const shortenedLink = await getShortedLink(inputValue);
+      await getShortedLink(inputValue);
+      const shortenedLink:LinkResponseData = await getShortedLink(inputValue);
       localStorage.setItem('links', JSON.stringify(shortenedLink));
       setShortenedLink(shortenedLink);
       setInputValue('');

--- a/src/components/ShortenLink/ShortedLink.tsx
+++ b/src/components/ShortenLink/ShortedLink.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { LinkInput } from '../LinkInput/LinkInput';
 import { ShortenedLinkItem } from '../ShortenedLinkItem/ShortenedLinkItem';
-import { ShortedLinkResult } from '../../types/types';
+import { LinkResponseData } from '../../types/types';
 
 export const ShortedLink = () => {
 
-  const [shortenedLink, setShortenedLink] = useState<ShortedLinkResult>();
+  const [shortenedLink, setShortenedLink] = useState<LinkResponseData>();
 
   return (
     <>

--- a/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
+++ b/src/components/ShortenedLinkItem/ShortenedLinkItem.tsx
@@ -1,15 +1,15 @@
 import { useState } from 'react';
-import { ShortedLinkResult } from '../../types/types';
+import { LinkResponseData } from '../../types/types';
 import { copyToClipboard } from '../../helpers/copyToClipboard';
 
-type ResultProps = { shortenedLink: ShortedLinkResult }
+type ResultProps = { shortenedLink: LinkResponseData }
 
 export const ShortenedLinkItem = ({shortenedLink}:ResultProps) => {
 
   const [copyText, setCopyText] = useState('Copy');
 
-  const originalLink = shortenedLink.original_link;
-  const shortLink = shortenedLink.full_short_link;  
+  const originalLink = shortenedLink.long_url;
+  const shortLink = shortenedLink.link;  
 
   const handleCopyText = async ():Promise<void> => {
     try {

--- a/src/helpers/getShortedLink.ts
+++ b/src/helpers/getShortedLink.ts
@@ -1,12 +1,24 @@
-import { LinkResponseBody, ShortedLinkResult } from '../types/types';
+import { LinkResponseData } from '../types/types';
 
-export const getShortedLink = async (url:string):Promise<ShortedLinkResult> => {
-  const urlFetch = `https://api.shrtco.de/v2/shorten?url=${url}`;
+export const getShortedLink = async (url:string):Promise<LinkResponseData> => {
+  const urlFetch = 'https://api-ssl.bitly.com/v4/shorten';
+  const TOKEN = 'a85b332002cff2c70a9e2416014ffd17cecb830c'; 
+  const fetchOptions = {
+    method: 'POST',
+    headers: {
+        'Authorization': `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      "long_url": `${url}`,
+      "domain": "bit.ly",
+    })
+  }
 
-  const response = await fetch(urlFetch);
-  const data:LinkResponseBody = await response.json();
+  const response = await fetch(urlFetch,fetchOptions);
+  const data:LinkResponseData = await response.json();
 
-  if(!response.ok) throw data.error;
+  if(!response.ok) throw data;
 
-  return {...data.result}
+  return data;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,9 +1,5 @@
-export type LinkResponseBody = {
-  result: ShortedLinkResult;
-  error?:string
-}
-
-export type ShortedLinkResult = {
-  full_short_link: string;
-  original_link: string;
+export type LinkResponseData = {
+  id: string,
+  link: string,
+  long_url: string,
 }


### PR DESCRIPTION
Se reemplazó la API para acortar enlaces.

_Anterior:_ [shrtcode API](https://app.shrtco.de/)

**Nueva:** [Bitly API](https://app.bitly.com/)